### PR TITLE
Support payment format version 2

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -154,6 +154,39 @@ describe('🚫  Middleware Cognito Groups Authorizer', () => {
     expect(body).toEqual({ foo: 'bar' })
   })
 
+  test('It should authorize the user if at least one cognito:groups matches with authorized roles (v2 request)', async () => {
+    const handler = middy((event, context, cb) => {
+      cb(null, event.body) // propagates the body as a response
+    })
+
+    handler.use(cognitoGroupsAuthorizer({
+      allowedRoles: ['Admin']
+    }))
+
+    // invokes the handler
+    const event = {
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: {
+        foo: 'bar'
+      },
+      requestContext: {
+        authorizer: {
+          claims: {
+            jwt: {
+              'cognito:groups': ['Admin', 'User']
+            }
+          }
+        }
+      }
+    }
+
+    const body = await invoke(handler, event)
+
+    expect(body).toEqual({ foo: 'bar' })
+  })
+
   test('It should authorize the user if cognito:groups matches with authorized roles', async () => {
     const handler = middy((event, context, cb) => {
       cb(null, event.body) // propagates the body as a response

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -173,8 +173,8 @@ describe('🚫  Middleware Cognito Groups Authorizer', () => {
       },
       requestContext: {
         authorizer: {
-          claims: {
-            jwt: {
+          jwt: {
+            claims: {
               'cognito:groups': ['Admin', 'User']
             }
           }

--- a/index.js
+++ b/index.js
@@ -29,7 +29,8 @@ module.exports = (opts) => {
         throw new createError.Unauthorized('Unauthorized')
       }
 
-      let userGroups = 'cognito:groups' in authorizer.claims ? authorizer.claims['cognito:groups'] : []
+      const claims = 'jwt' in authorizer.claims ? authorizer.claims['jwt'] : authorizer.claims;
+      let userGroups = 'cognito:groups' in claims ? claims['cognito:groups'] : []
 
       if (typeof userGroups === 'string') {
         userGroups = [userGroups]

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = (opts) => {
         throw new createError.Unauthorized('Unauthorized')
       }
 
-      const claims = 'jwt' in authorizer.claims ? authorizer.claims['jwt'] : authorizer.claims;
+      const claims = authorizer.claims || authorizer.jwt.claims;
       let userGroups = 'cognito:groups' in claims ? claims['cognito:groups'] : []
 
       if (typeof userGroups === 'string') {


### PR DESCRIPTION
See https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html

Unfortunately AWS don't have a good example on their site including the authorizer block. But, when V2 is used the cognito:groups appear in a different place in the request message. In v1 they are inside requestContext.authorizer.claims, with v2 they are inside requestContext.authorizer.jwt.claims.

I've added an example in the tests.